### PR TITLE
Add design assets to the project

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 <img src="assets/1742951217707.jpg" alt="[Descriptive Alt Text Here]">
 <img src="assets/patterns.png" alt="[Descriptive Alt Text Here]">
     <img src="assets/table.png" alt="Design Asset 3">
-    <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="Design Asset 4">
+<img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="[Descriptive Alt Text Here]">
     <img src="assets/OIP.jpeg" alt="Design Asset 5">
     <img src="assets/IMG_20250324_074857.jpg" alt="Design Asset 6">
   </div>

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
 <img src="assets/table.png" alt="[Descriptive Alt Text Here]">
 <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="[Descriptive Alt Text Here]">
 <img src="assets/OIP.jpeg" alt="[Descriptive Alt Text Here]">
-    <img src="assets/IMG_20250324_074857.jpg" alt="Design Asset 6">
+<img src="assets/IMG_20250324_074857.jpg" alt="[Descriptive Alt Text Here]">
   </div>
 
   <footer>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
     <h2>Design Assets</h2>
 <img src="assets/1742951217707.jpg" alt="[Descriptive Alt Text Here]">
 <img src="assets/patterns.png" alt="[Descriptive Alt Text Here]">
-    <img src="assets/table.png" alt="Design Asset 3">
+<img src="assets/table.png" alt="[Descriptive Alt Text Here]">
 <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="[Descriptive Alt Text Here]">
 <img src="assets/OIP.jpeg" alt="[Descriptive Alt Text Here]">
     <img src="assets/IMG_20250324_074857.jpg" alt="Design Asset 6">

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
   <!-- Added Images -->
   <div class="container">
     <h2>Design Assets</h2>
-    <img src="assets/1742951217707.jpg" alt="Design Asset 1">
+<img src="assets/1742951217707.jpg" alt="[Descriptive Alt Text Here]">
     <img src="assets/patterns.png" alt="Design Asset 2">
     <img src="assets/table.png" alt="Design Asset 3">
     <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="Design Asset 4">

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
   <div class="container">
     <h2>Design Assets</h2>
 <img src="assets/1742951217707.jpg" alt="[Descriptive Alt Text Here]">
-    <img src="assets/patterns.png" alt="Design Asset 2">
+<img src="assets/patterns.png" alt="[Descriptive Alt Text Here]">
     <img src="assets/table.png" alt="Design Asset 3">
     <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="Design Asset 4">
     <img src="assets/OIP.jpeg" alt="Design Asset 5">

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
 <img src="assets/patterns.png" alt="[Descriptive Alt Text Here]">
     <img src="assets/table.png" alt="Design Asset 3">
 <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="[Descriptive Alt Text Here]">
-    <img src="assets/OIP.jpeg" alt="Design Asset 5">
+<img src="assets/OIP.jpeg" alt="[Descriptive Alt Text Here]">
     <img src="assets/IMG_20250324_074857.jpg" alt="Design Asset 6">
   </div>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Open Graph Meta Tags -->
   <meta property="og:title" content="Spykey GitHub Site">
   <meta property="og:description" content="A comprehensive guide to software development for local and cloud environments, along with tips on security-focused operating systems.">
-  <meta property="og:image" content="URL_to_image">
+  <meta property="og:image" content="assets/1742951217707.jpg">
   <meta property="og:url" content="https://spykeydp.github.io/">
   <meta name="twitter:card" content="summary_large_image">
 
@@ -184,6 +184,17 @@
       <li><a href="https://github.com/features/copilot">GitHub Copilot</a>: An AI-powered code completion tool that provides suggestions and helps you write code faster.</li>
       <li><a href="https://www.openai.com/gemini" target="blank">Gemini 2.0</a>: OpenAI's advanced language model for generating human-like responses and assistance in various tasks.</li>
     </ul>
+  </div>
+
+  <!-- Added Images -->
+  <div class="container">
+    <h2>Design Assets</h2>
+    <img src="assets/1742951217707.jpg" alt="Design Asset 1">
+    <img src="assets/patterns.png" alt="Design Asset 2">
+    <img src="assets/table.png" alt="Design Asset 3">
+    <img src="assets/1029902f-af2a-4b81-827b-170f94301d97.png" alt="Design Asset 4">
+    <img src="assets/OIP.jpeg" alt="Design Asset 5">
+    <img src="assets/IMG_20250324_074857.jpg" alt="Design Asset 6">
   </div>
 
   <footer>


### PR DESCRIPTION
Related to #1

Integrate design assets into the project as per the issue description.

* **index.html**
  - Add `<img>` tags to include the provided images.
  - Update the `og:image` meta tag to reference `assets/1742951217707.jpg`.

* **Assets Directory**
  - Add `1742951217707.jpg`, `patterns.png`, `table.png`, `1029902f-af2a-4b81-827b-170f94301d97.png`, `OIP.jpeg`, and `IMG_20250324_074857.jpg` to the `assets` directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spykeydp/spykeydp.github.io/pull/2?shareId=96fb21ea-f1df-453b-b75b-c00ab9a1a620).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced social sharing by updating the meta tag to display the correct image.
	- Introduced a new "Design Assets" section featuring six images with accessibility attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->